### PR TITLE
switch from userid to anonymousid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ var Batch = require('batch');
 var InsideVault = module.exports = integration('InsideVault')
   .endpoint('https://tr.staticiv.com/tracker/px/')
   .ensure('settings.clientId')
-  .ensure('message.userId')
+  .ensure('message.anonymousId')
   .channels(['server'])
   .mapping('events')
   .mapper(mapper)

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -64,7 +64,7 @@ exports.random = function(){
 
 function common(facade){
   return {
-    u: facade.userId(),
+    u: facade.anonymousId(),
     t: facade.timestamp().getTime(),
     z: 0,
     r: exports.random()

--- a/test/fixtures/page-basic.json
+++ b/test/fixtures/page-basic.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "page",
-    "userId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
+    "anonymousId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
     "timestamp":"2014",
     "properties": {
       "url": "https://segment.io/docs/tracking-api/page-and-screen/",

--- a/test/fixtures/track-bare.json
+++ b/test/fixtures/track-bare.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "userId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
+    "anonymousId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
     "event": "user_state_change:Applied",
     "timestamp": "2014",
     "properties": {

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "userId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
+    "anonymousId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
     "timestamp": "2014",
     "event": "user_state_change:Applied",
     "properties": {

--- a/test/fixtures/track-multi.json
+++ b/test/fixtures/track-multi.json
@@ -7,7 +7,7 @@
   },
   "input": {
     "type": "track",
-    "userId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
+    "anonymousId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
     "timestamp": "2014",
     "event": "some_event",
     "properties": {

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ describe('Inside Vault', function(){
       .name('InsideVault')
       .channels(['server'])
       .ensure('settings.clientId')
-      .ensure('message.userId')
+      .ensure('message.anonymousId')
   });
 
   describe('.validate()', function() {
@@ -37,9 +37,9 @@ describe('Inside Vault', function(){
     });
 
     it('should be valid with complete settings', function(){
-      test.valid({userId:'abc'}, settings);
+      test.valid({anonymousId:'abc'}, settings);
     });
-    it('should require valid userId', function(){
+    it('should require valid anonymousId', function(){
       test.invalid({}, settings);
     });
   });


### PR DESCRIPTION
To match the client side change. 

Literally our only customer using this is simple, so s'all good: https://modeanalytics.com/segment/reports/99908f0ac4f8/runs/5f4413dc2521

Will write integration docs saying that to use IV on the server and get any use of it its imperative to pass back the segment anonymousId from the client and use that.
