### PR TITLE
add optional noclick for order-attributed conversions

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -18,10 +18,11 @@ var has = Object.prototype.hasOwnProperty;
 
 exports.track = function(track){
   var events = this.events(track.event());
+  var noclick = this.settings.noclick;
   var revenue = track.revenue() || track.value() || 0;
   var actid = track.orderId() || '';
   return events.map(function(event){
-    var payload = common(track);
+    var payload = common(track, noclick);
     payload.act = event;
     payload.actv = revenue;
     payload.actcid = actid || '';
@@ -40,7 +41,8 @@ exports.track = function(track){
  */
 
 exports.page = function(page){
-  var payload = common(page);
+  var noclick = this.settings.noclick;
+  var payload = common(page, noclick);
   payload.url = page.url() || '';
   payload.ref = page.referrer() || '';
   payload.a = 1;
@@ -62,9 +64,10 @@ exports.random = function(){
  * @return {Object}
  */
 
-function common(facade){
+function common(facade, noclick){
+  var id = noclick ? 'noclick' : facade.anonymousId();
   return {
-    u: facade.anonymousId(),
+    u: id,
     t: facade.timestamp().getTime(),
     z: 0,
     r: exports.random()

--- a/test/fixtures/track-noclick.json
+++ b/test/fixtures/track-noclick.json
@@ -1,0 +1,45 @@
+{
+  "settings": {
+    "events": [
+      { "key": "some_event", "value": "event2" },
+      { "key": "some_event", "value": "event3" }
+    ],
+    "noclick": true
+  },
+  "input": {
+    "type": "track",
+    "anonymousId": "702F48C3-7F9A-45D9-B229-17EB2B037623",
+    "timestamp": "2014",
+    "event": "some_event",
+    "properties": {
+      "url": "https://segment.io/docs/tracking-api/page-and-screen/",
+      "revenue": 99.92,
+      "orderId": "3-abcd"
+    },
+    "context": {
+      "ip": "10.0.0.1",
+      "referrer": {
+        "url":"https://segment.io/integrations"
+      }
+    }
+  },
+  "output": [{
+    "u": "noclick",
+    "t": 1388534400000,
+    "z": 0,
+    "r": 0,
+    "act": "event2",
+    "actv": 99.92,
+    "actcid": "3-abcd",
+    "a": 3
+  },{
+    "u": "noclick",
+    "t": 1388534400000,
+    "z": 0,
+    "r": 0,
+    "act": "event3",
+    "actv": 99.92,
+    "actcid": "3-abcd",
+    "a": 3
+  }]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -53,11 +53,17 @@ describe('Inside Vault', function(){
       it('should map multi track', function(){
         test.maps('track-multi');
       });
-    });
 
-    it('should map bare track', function(){
+      it('should map bare track', function(){
         test.maps('track-bare');
       });
+
+      it('should map noclick', function(){
+        test.maps('track-noclick');
+      });
+    });
+
+
 
     describe('page', function(){
       it('should map basic page', function(){


### PR DESCRIPTION
For new inside vault feature that ties conversions together via their corresponding orderId (conversion ID) instead of via a persistent user ID since IV cannot alias IDs. Questionably value vs. just passing the anonId back to the client, but this is for our one single mutual customer (simple) and does add support for a new feature they've added:

> Conversions where the pixel-user-id is set to "noclick" will indicate to InsideVault that the conversion should not be matched to a click directly, but instead to a conversion through the conversion id (and indirectly to the initial click). Thus the client-side conversion, which has the pixel-user-id of the click as well as the conversion id of server-side conversions, contains the information needed to glue server-side conversions client-side clicks.
